### PR TITLE
feat: intelligent model alias upgrades (Claude 3→4, GPT-4→5, GLM-4→5)

### DIFF
--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -18,6 +18,7 @@ import {
   markProviderCreditsExhausted
 } from '../services/credits';
 import { getAdapterForProvider } from '../utils/transform';
+import { resolveModelAlias } from '../utils/model-aliases';
 import { createStreamingResponseWithUsage } from '../utils/streaming';
 import { fetchWithRetry } from '../utils/retry';
 import { chatCompletionRequestSchema } from '../schemas/chat';
@@ -197,7 +198,7 @@ async function handleHeaderDrivenRequest(
     return c.json(errorPayload, 400);
   }
 
-  const model = hints.requestedModel || body.model || client.defaultModel || 'gpt-4o';
+  const model = resolveModelAlias(hints.requestedModel || body.model || client.defaultModel || 'gpt-4o');
   const routePlan = buildRoutePlan(policy, hints, model);
 
   updateTelemetryMetadata(c, 'unresolved', routePlan.model || model, rawBody, {
@@ -448,7 +449,7 @@ async function handleLegacyRequest(
   requestStart: number,
   hasRetriedCreditFallback = false
 ): Promise<Response> {
-  const model = body.model || client.defaultModel || 'gpt-4o';
+  const model = resolveModelAlias(body.model || client.defaultModel || 'gpt-4o');
   const routeId = createLegacyRouteId();
 
   let route: Awaited<ReturnType<typeof determineProvider>>;

--- a/src/services/router.ts
+++ b/src/services/router.ts
@@ -72,7 +72,7 @@ export async function determineProvider(
   }
 
   // 3. OpenAI Direct - if credits available
-  if ((model.includes('gpt') || model.startsWith('o1')) && creditsOpenAI) {
+  if ((model.includes('gpt') || /^o\d/.test(model)) && creditsOpenAI) {
     return {
       provider: 'openai-direct',
       url: 'https://api.openai.com/v1/chat/completions',

--- a/src/utils/model-aliases.ts
+++ b/src/utils/model-aliases.ts
@@ -1,0 +1,50 @@
+/**
+ * Intelligent model alias/upgrade mappings.
+ * Maps deprecated or older model identifiers to their current equivalents,
+ * preserving capability tier (opus/sonnet/haiku, flagship/mini, etc.).
+ *
+ * Applied before provider routing so the correct provider is targeted.
+ * Current models pass through unchanged.
+ */
+
+const MODEL_ALIASES: Array<{ pattern: RegExp; replacement: string }> = [
+  // === Anthropic Claude ===
+
+  // Opus tier: claude-3-opus-* → claude-opus-4-6
+  { pattern: /^claude-3-opus/i, replacement: 'claude-opus-4-6' },
+
+  // Sonnet tier: claude-3-sonnet-*, claude-3-5-sonnet-*, claude-3-7-sonnet-* → claude-sonnet-4-6
+  { pattern: /^claude-3.*-sonnet/i, replacement: 'claude-sonnet-4-6' },
+
+  // Haiku tier: claude-3-haiku-*, claude-3-5-haiku-* → claude-haiku-4-5-20251001
+  { pattern: /^claude-3.*-haiku/i, replacement: 'claude-haiku-4-5-20251001' },
+
+  // === OpenAI GPT ===
+
+  // Budget tier: gpt-4o-mini → gpt-5-mini (must precede gpt-4 pattern)
+  { pattern: /^gpt-4o-mini/i, replacement: 'gpt-5-mini' },
+
+  // Budget tier: gpt-3.5-* → gpt-5-mini
+  { pattern: /^gpt-3\.5/i, replacement: 'gpt-5-mini' },
+
+  // Flagship tier: gpt-4o, gpt-4-turbo, gpt-4 → gpt-5-2
+  { pattern: /^gpt-4/i, replacement: 'gpt-5-2' },
+
+  // === Z.ai / GLM ===
+
+  // GLM-4.x series → glm-5
+  { pattern: /^glm-4/i, replacement: 'glm-5' },
+];
+
+/**
+ * Resolve a model name to its current canonical equivalent.
+ * Returns the model unchanged if it is already current or unrecognised.
+ */
+export function resolveModelAlias(model: string): string {
+  for (const { pattern, replacement } of MODEL_ALIASES) {
+    if (pattern.test(model)) {
+      return replacement;
+    }
+  }
+  return model;
+}

--- a/tests/unit/router.test.ts
+++ b/tests/unit/router.test.ts
@@ -7,7 +7,7 @@ describe('determineProvider', () => {
   const mockClient: ClientConfig = {
     appId: 'test-app',
     name: 'Test App',
-    defaultModel: 'gpt-4o',
+    defaultModel: 'gpt-5-2',
     allowZai: true,
     fallbackStrategy: 'openrouter',
     rateLimit: {
@@ -41,41 +41,48 @@ describe('determineProvider', () => {
   });
 
   it('should route to Z.ai for glm models', async () => {
-    const route = await determineProvider('glm-4-plus', mockClient, mockEnv);
+    const route = await determineProvider('glm-5', mockClient, mockEnv);
     expect(route.provider).toBe('z-ai-pro');
     expect(route.url).toBe('https://api.z.ai/api/coding/paas/v4/chat/completions');
   });
 
   it('should route to Anthropic for claude models with credits', async () => {
     const envWithCredits = { ...mockEnv, CREDITS_ANTHROPIC: 'true' };
-    const route = await determineProvider('claude-3-5-sonnet', mockClient, envWithCredits);
+    const route = await determineProvider('claude-sonnet-4-6', mockClient, envWithCredits);
     expect(route.provider).toBe('anthropic-direct');
     expect(route.url).toContain('anthropic.com');
   });
 
   it('should route to OpenAI for gpt models with credits', async () => {
     const envWithCredits = { ...mockEnv, CREDITS_OPENAI: 'true' };
-    const route = await determineProvider('gpt-4o', mockClient, envWithCredits);
+    const route = await determineProvider('gpt-5-2', mockClient, envWithCredits);
+    expect(route.provider).toBe('openai-direct');
+    expect(route.url).toContain('openai.com');
+  });
+
+  it('should route to OpenAI for o-series reasoning models with credits', async () => {
+    const envWithCredits = { ...mockEnv, CREDITS_OPENAI: 'true' };
+    const route = await determineProvider('o3', mockClient, envWithCredits);
     expect(route.provider).toBe('openai-direct');
     expect(route.url).toContain('openai.com');
   });
 
   it('should fallback to OpenRouter when credits exhausted', async () => {
-    const route = await determineProvider('claude-3-5-sonnet', mockClient, mockEnv);
+    const route = await determineProvider('claude-sonnet-4-6', mockClient, mockEnv);
     expect(route.provider).toBe('openrouter');
     expect(route.url).toContain('openrouter.ai');
   });
 
   it('should fail-fast when fallback strategy is fail-fast', async () => {
     const failFastClient = { ...mockClient, fallbackStrategy: 'fail-fast' as const };
-    await expect(determineProvider('claude-3-5-sonnet', failFastClient, mockEnv))
+    await expect(determineProvider('claude-sonnet-4-6', failFastClient, mockEnv))
       .rejects
       .toThrow('Payment Required');
   });
 
   it('should use default model when model is not specified', async () => {
     const envWithCredits = { ...mockEnv, CREDITS_OPENAI: 'true' };
-    // When no model is specified in request, chat.ts falls back to client.defaultModel
+    // When no model is specified in request, chat.ts falls back to client.defaultModel (already aliased)
     const route = await determineProvider(mockClient.defaultModel, mockClient, envWithCredits);
     expect(route.provider).toBe('openai-direct');
   });

--- a/tests/unit/routes/chat.test.ts
+++ b/tests/unit/routes/chat.test.ts
@@ -278,7 +278,7 @@ describe('Chat Route - /v1/chat/completions', () => {
                     'Authorization': `Bearer ${TEST_API_KEY}`
                 },
                 body: JSON.stringify({
-                    model: 'glm-4.6',
+                    model: 'glm-5',
                     messages: [{ role: 'user', content: 'Hello' }]
                 })
             });
@@ -409,7 +409,7 @@ describe('Chat Route - /v1/chat/completions', () => {
                     'Authorization': `Bearer ${TEST_API_KEY}`
                 },
                 body: JSON.stringify({
-                    model: 'claude-3-5-sonnet',
+                    model: 'claude-sonnet-4-6',
                     messages: [{ role: 'user', content: 'Hello' }]
                 })
             });

--- a/tests/unit/utils/model-aliases.test.ts
+++ b/tests/unit/utils/model-aliases.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { resolveModelAlias } from '../../../src/utils/model-aliases';
+
+describe('resolveModelAlias', () => {
+  describe('Claude', () => {
+    it('maps claude-3-opus variants to claude-opus-4-6', () => {
+      expect(resolveModelAlias('claude-3-opus')).toBe('claude-opus-4-6');
+      expect(resolveModelAlias('claude-3-opus-20240229')).toBe('claude-opus-4-6');
+    });
+
+    it('maps claude-3-sonnet variants to claude-sonnet-4-6', () => {
+      expect(resolveModelAlias('claude-3-sonnet-20240229')).toBe('claude-sonnet-4-6');
+      expect(resolveModelAlias('claude-3-5-sonnet')).toBe('claude-sonnet-4-6');
+      expect(resolveModelAlias('claude-3-5-sonnet-20241022')).toBe('claude-sonnet-4-6');
+      expect(resolveModelAlias('claude-3-7-sonnet-20250219')).toBe('claude-sonnet-4-6');
+    });
+
+    it('maps claude-3-haiku variants to claude-haiku-4-5-20251001', () => {
+      expect(resolveModelAlias('claude-3-haiku')).toBe('claude-haiku-4-5-20251001');
+      expect(resolveModelAlias('claude-3-haiku-20240307')).toBe('claude-haiku-4-5-20251001');
+      expect(resolveModelAlias('claude-3-5-haiku')).toBe('claude-haiku-4-5-20251001');
+      expect(resolveModelAlias('claude-3-5-haiku-20241022')).toBe('claude-haiku-4-5-20251001');
+    });
+
+    it('passes through current claude-4 models unchanged', () => {
+      expect(resolveModelAlias('claude-sonnet-4-6')).toBe('claude-sonnet-4-6');
+      expect(resolveModelAlias('claude-opus-4-6')).toBe('claude-opus-4-6');
+      expect(resolveModelAlias('claude-haiku-4-5-20251001')).toBe('claude-haiku-4-5-20251001');
+    });
+  });
+
+  describe('OpenAI', () => {
+    it('maps gpt-4o-mini variants to gpt-5-mini', () => {
+      expect(resolveModelAlias('gpt-4o-mini')).toBe('gpt-5-mini');
+      expect(resolveModelAlias('gpt-4o-mini-2024-07-18')).toBe('gpt-5-mini');
+    });
+
+    it('maps gpt-4o and gpt-4 variants to gpt-5-2', () => {
+      expect(resolveModelAlias('gpt-4o')).toBe('gpt-5-2');
+      expect(resolveModelAlias('gpt-4o-2024-11-20')).toBe('gpt-5-2');
+      expect(resolveModelAlias('gpt-4-turbo')).toBe('gpt-5-2');
+      expect(resolveModelAlias('gpt-4')).toBe('gpt-5-2');
+    });
+
+    it('maps gpt-3.5 variants to gpt-5-mini', () => {
+      expect(resolveModelAlias('gpt-3.5-turbo')).toBe('gpt-5-mini');
+      expect(resolveModelAlias('gpt-3.5-turbo-0125')).toBe('gpt-5-mini');
+    });
+
+    it('passes through current gpt-5 models unchanged', () => {
+      expect(resolveModelAlias('gpt-5-2')).toBe('gpt-5-2');
+      expect(resolveModelAlias('gpt-5-mini')).toBe('gpt-5-mini');
+    });
+  });
+
+  describe('GLM / Z.ai', () => {
+    it('maps glm-4 variants to glm-5', () => {
+      expect(resolveModelAlias('glm-4')).toBe('glm-5');
+      expect(resolveModelAlias('glm-4-plus')).toBe('glm-5');
+      expect(resolveModelAlias('glm-4.6')).toBe('glm-5');
+    });
+
+    it('passes through glm-5 unchanged', () => {
+      expect(resolveModelAlias('glm-5')).toBe('glm-5');
+    });
+  });
+
+  describe('pass-through', () => {
+    it('returns unrecognised model names unchanged', () => {
+      expect(resolveModelAlias('some-custom-model')).toBe('some-custom-model');
+      expect(resolveModelAlias('accounts/fireworks/models/llama-v3p1-8b-instruct')).toBe('accounts/fireworks/models/llama-v3p1-8b-instruct');
+      expect(resolveModelAlias('openai/gpt-5')).toBe('openai/gpt-5');
+    });
+
+    it('is case-insensitive', () => {
+      expect(resolveModelAlias('Claude-3-5-Sonnet')).toBe('claude-sonnet-4-6');
+      expect(resolveModelAlias('GPT-4O')).toBe('gpt-5-2');
+      expect(resolveModelAlias('GLM-4-Plus')).toBe('glm-5');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Model alias system**: New `src/utils/model-aliases.ts` maps deprecated model names to current equivalents before routing, so old `defaultModel` values in client configs and explicit request model fields auto-upgrade
- **Routing coverage**: `router.ts` o-series detection broadened from `startsWith('o1')` to `/^o\d/` to cover o3, o4, etc.
- **Test hygiene**: Router and chat tests updated to use current model names; 12-case unit test suite added for `resolveModelAlias`

| Old model | → | New model |
|---|---|---|
| `claude-3-opus-*` | → | `claude-opus-4-6` |
| `claude-3*-sonnet-*` | → | `claude-sonnet-4-6` |
| `claude-3*-haiku-*` | → | `claude-haiku-4-5-20251001` |
| `gpt-4o-mini*` | → | `gpt-5-mini` |
| `gpt-4*` | → | `gpt-5-2` |
| `gpt-3.5*` | → | `gpt-5-mini` |
| `glm-4*` | → | `glm-5` |

## Test plan

- [x] `npm run test:unit` — 149/149 passing
- [x] `tsc --noEmit` — no type errors
- [ ] Smoke test a request through the deployed worker with an old model name (e.g. `claude-3-5-sonnet`) and verify the `x-corvo-cortex-model` response header shows `claude-sonnet-4-6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a model alias system that auto-upgrades deprecated model names to current ones before routing. Also expands OpenAI o‑series detection to route o3/o4+ correctly.

- **New Features**
  - Auto-upgrade aliases applied in both header-driven and legacy chat paths (e.g., Claude 3→Claude 4 tiers, GPT‑4/3.5→GPT‑5, gpt‑4o‑mini→gpt‑5‑mini, GLM‑4→GLM‑5) so old client configs and requests keep working.

- **Bug Fixes**
  - Broadened OpenAI o‑series routing from o1-only to /^o\d/ to cover o3/o4+.
  - Updated tests to current model names and added a focused suite for alias resolution.

<sup>Written for commit 67dec1d25d16cce717b6045e82c7569655982d8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended OpenAI Direct routing to support a broader set of o-series and GPT model variants.

* **Improvements**
  * Implemented centralized model name resolution for consistent handling across all supported providers (Anthropic Claude, OpenAI GPT, and GLM families).

* **Tests**
  * Updated test fixtures and assertions to validate new model routing behavior and naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->